### PR TITLE
make FOODER logo clickable and redirect to today's diary

### DIFF
--- a/lib/screens/main.dart
+++ b/lib/screens/main.dart
@@ -74,7 +74,15 @@ class _MainScreen extends State<MainScreen> {
       title = Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          const Text("🅵🅾🅾🅳🅴🆁"),
+          TextButton(
+            child: const Text("🅵🅾🅾🅳🅴🆁", style: const TextStyle(fontSize: 20, color: Colors.white)),
+            onPressed: () {
+              Navigator.pushReplacement(
+                context,
+                MaterialPageRoute(builder: (context) => MainScreen(apiClient: widget.apiClient)),
+              ).then((_) => _asyncInitState());
+            },
+          ),
           const Spacer(),
           Text(
             "${date.year}-${date.month}-${date.day}",


### PR DESCRIPTION
[Redirect user to diary of current date upon clicking on 'FOODER' logo](https://github.com/ickyicky/fooder_web/issues/5)
Here I used initState cause setState introduced a bug with diary not being refreshed upon date change