### PR TITLE
set meal name color to cyan

### DIFF
--- a/lib/widgets/meal.dart
+++ b/lib/widgets/meal.dart
@@ -28,7 +28,9 @@ class MealWidget extends StatelessWidget {
                     Expanded(
                       child: Text(
                         meal.name,
-                        style: Theme.of(context).textTheme.titleLarge,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                          ),
                       ),
                     ),
                     Text("${meal.calories.toStringAsFixed(1)} kcal"),


### PR DESCRIPTION
Colored meal names to make difference between meals and entries:
![image](https://github.com/ickyicky/fooder_web/assets/85220613/8db8821e-e08c-4429-a9ae-ee6d1fb8ecec)
