### PR TITLE
potential fix by setting constraints

### DIFF
--- a/lib/widgets/diary.dart
+++ b/lib/widgets/diary.dart
@@ -20,6 +20,7 @@ class DiaryWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
+      constraints: const BoxConstraints(maxWidth: 720),
       padding: const EdgeInsets.all(8),
       child: CustomScrollView(
         slivers: <Widget>[


### PR DESCRIPTION
Upon investigation I think that 'FOODER' logo breaking while scrolling down on mobile device (where the width is limited in comparison to desktop, and there is no place for scrollbar to show up) may be fixed by setting constraints to the `CustomScrollView`. Proceed with caution - untested on mobile device xD 